### PR TITLE
Fix: add missing @babel/runtime dependency to AppShell

### DIFF
--- a/AppShell/package.json
+++ b/AppShell/package.json
@@ -17,6 +17,7 @@
     "author": "Luca Mezzalira",
     "license": "ISC",
     "dependencies": {
+        "@babel/runtime": "^7.26.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.21.3",


### PR DESCRIPTION
## Summary
`@babel/plugin-transform-runtime` is configured in AppShell but `@babel/runtime` is not listed as a dependency. This works with npm's permissive hoisting but fails with pnpm's strict module isolation, causing build errors on `pnpm start`:

```
Module not found: Error: Can't resolve '@babel/runtime/helpers/toConsumableArray'
Module not found: Error: Can't resolve '@babel/runtime/helpers/asyncToGenerator'
Module not found: Error: Can't resolve '@babel/runtime/helpers/slicedToArray'
Module not found: Error: Can't resolve '@babel/runtime/regenerator'
```

## Changes
- Added `@babel/runtime` as a dependency in `AppShell/package.json`

## Test plan
- [x] `pnpm install && pnpm start` — AppShell compiles without errors
- [x] Verified from a clean clone with a fresh `pnpm install`