### PR TITLE
Add start:discovery script for serving frontend-discovery.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,20 @@ pnpm install
 
 ### Running All Services
 
-Start all micro-frontends in parallel:
+In one terminal, start the discovery service that serves `frontend-discovery.json`:
+
+```bash
+pnpm run start:discovery
+```
+
+In another terminal, start all micro-frontends in parallel:
 
 ```bash
 pnpm start
 ```
 
 This will start all 6 services in parallel:
-- **AppShell** (port 2000) - Main application shell
+- **AppShell** (port 2000) - Main application shell (open this in the browser)
 - **CatalogueMFE** (port 2002) - Product catalogue
 - **HomeMFE** (port 2001) - Homepage
 - **MyAccount** (port 2003) - User account management

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "private": true,
   "scripts": {
     "start": "pnpm run --recursive --parallel start",
+    "start:discovery": "serve -l 8080 --cors .",
     "build": "pnpm run --recursive build",
     "build:parallel": "pnpm run --recursive --parallel build"
+  },
+  "devDependencies": {
+    "serve": "^14.2.4"
   }
 }
 


### PR DESCRIPTION
## Summary
Added a `start:discovery` script in the root `package.json` and `serve` as a devDependency, so the discovery service can be started with `pnpm run start:discovery` before running `pnpm start`.

Updated README with instructions for starting the discovery service in a separate terminal.

## Changes
- `package.json`: added `start:discovery` script and `serve` devDependency
- `README.md`: added discovery service startup instructions

## Test plan
- [x] `pnpm install` installs `serve`
- [x] `pnpm run start:discovery` serves `frontend-discovery.json` on port 8080
- [x] `pnpm start` in another terminal starts all 6 MFEs, all compile successfully
- [x] `http://localhost:2000` loads the full application with all routes working

Closes #4